### PR TITLE
Avoid double call to the Database

### DIFF
--- a/src/main/java/com/alibou/security/auth/AuthenticationService.java
+++ b/src/main/java/com/alibou/security/auth/AuthenticationService.java
@@ -34,14 +34,14 @@ public class AuthenticationService {
   }
 
   public AuthenticationResponse authenticate(AuthenticationRequest request) {
-    authenticationManager.authenticate(
+    final String email = request.getEmail();
+    Authentication authentication = authenticationManager.authenticate(
         new UsernamePasswordAuthenticationToken(
             request.getEmail(),
             request.getPassword()
         )
     );
-    var user = repository.findByEmail(request.getEmail())
-        .orElseThrow();
+    var user = (User) authentication.getPrincipal();
     var jwtToken = jwtService.generateToken(user);
     return AuthenticationResponse.builder()
         .token(jwtToken)


### PR DESCRIPTION
By retrieving the user from the authentication you avoid a double call to the database which in turn increases your performance.
Also forgot to delete line 37 in my pull.