### PR TITLE
Updated JwtService.java  to match hours

### DIFF
--- a/src/main/java/com/alibou/security/config/JwtService.java
+++ b/src/main/java/com/alibou/security/config/JwtService.java
@@ -40,7 +40,7 @@ public class JwtService {
         .setClaims(extraClaims)
         .setSubject(userDetails.getUsername())
         .setIssuedAt(new Date(System.currentTimeMillis()))
-        .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 24))
+        .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24))
         .signWith(getSignInKey(), SignatureAlgorithm.HS256)
         .compact();
   }


### PR DESCRIPTION
updated JwtService.java generatetoken() method .setExpiration to be in hours instead of minutes