### PR TITLE
Refactor to comply with JDK 17 code standards

### DIFF
--- a/src/main/java/com/alibou/security/SecurityApplication.java
+++ b/src/main/java/com/alibou/security/SecurityApplication.java
@@ -2,7 +2,7 @@ package com.alibou.security;
 
 import com.alibou.security.auth.AuthenticationService;
 import com.alibou.security.auth.RegisterRequest;
-import com.alibou.security.user.Role;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import static com.alibou.security.user.Role.ADMIN;
 import static com.alibou.security.user.Role.MANAGER;
 
+@Slf4j
 @SpringBootApplication
 public class SecurityApplication {
 
@@ -30,7 +31,7 @@ public class SecurityApplication {
 					.password("password")
 					.role(ADMIN)
 					.build();
-			System.out.println("Admin token: " + service.register(admin).getAccessToken());
+			log.debug("Admin token: " + service.register(admin).getAccessToken());
 
 			var manager = RegisterRequest.builder()
 					.firstname("Admin")
@@ -39,7 +40,7 @@ public class SecurityApplication {
 					.password("password")
 					.role(MANAGER)
 					.build();
-			System.out.println("Manager token: " + service.register(manager).getAccessToken());
+			log.debug("Manager token: " + service.register(manager).getAccessToken());
 
 		};
 	}

--- a/src/main/java/com/alibou/security/auth/AuthenticationService.java
+++ b/src/main/java/com/alibou/security/auth/AuthenticationService.java
@@ -4,7 +4,6 @@ import com.alibou.security.config.JwtService;
 import com.alibou.security.token.Token;
 import com.alibou.security.token.TokenRepository;
 import com.alibou.security.token.TokenType;
-import com.alibou.security.user.Role;
 import com.alibou.security.user.User;
 import com.alibou.security.user.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,13 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -71,7 +68,7 @@ public class AuthenticationService {
   private void saveUserToken(User user, String jwtToken) {
     var token = Token.builder()
         .user(user)
-        .token(jwtToken)
+        .tokenCode(jwtToken)
         .tokenType(TokenType.BEARER)
         .expired(false)
         .revoked(false)
@@ -97,12 +94,12 @@ public class AuthenticationService {
     final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
     final String refreshToken;
     final String userEmail;
-    if (authHeader == null ||!authHeader.startsWith("Bearer ")) {
+    if (Objects.isNull(authHeader) ||!authHeader.startsWith("Bearer ")) {
       return;
     }
     refreshToken = authHeader.substring(7);
     userEmail = jwtService.extractUsername(refreshToken);
-    if (userEmail != null) {
+    if (Objects.nonNull(userEmail)) {
       var user = this.repository.findByEmail(userEmail)
               .orElseThrow();
       if (jwtService.isTokenValid(refreshToken, user)) {

--- a/src/main/java/com/alibou/security/config/LogoutService.java
+++ b/src/main/java/com/alibou/security/config/LogoutService.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class LogoutService implements LogoutHandler {
@@ -23,13 +25,13 @@ public class LogoutService implements LogoutHandler {
   ) {
     final String authHeader = request.getHeader("Authorization");
     final String jwt;
-    if (authHeader == null ||!authHeader.startsWith("Bearer ")) {
+    if (Objects.isNull(authHeader) || !authHeader.startsWith("Bearer ")) {
       return;
     }
     jwt = authHeader.substring(7);
-    var storedToken = tokenRepository.findByToken(jwt)
+    var storedToken = tokenRepository.findByTokenCode(jwt)
         .orElse(null);
-    if (storedToken != null) {
+    if (Objects.nonNull(storedToken)) {
       storedToken.setExpired(true);
       storedToken.setRevoked(true);
       tokenRepository.save(storedToken);

--- a/src/main/java/com/alibou/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/alibou/security/config/SecurityConfiguration.java
@@ -1,12 +1,9 @@
 package com.alibou.security.config;
 
-import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,20 +13,10 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 
-import static com.alibou.security.user.Permission.ADMIN_CREATE;
-import static com.alibou.security.user.Permission.ADMIN_DELETE;
-import static com.alibou.security.user.Permission.ADMIN_READ;
-import static com.alibou.security.user.Permission.ADMIN_UPDATE;
-import static com.alibou.security.user.Permission.MANAGER_CREATE;
-import static com.alibou.security.user.Permission.MANAGER_DELETE;
-import static com.alibou.security.user.Permission.MANAGER_READ;
-import static com.alibou.security.user.Permission.MANAGER_UPDATE;
+import static com.alibou.security.user.Permission.*;
 import static com.alibou.security.user.Role.ADMIN;
 import static com.alibou.security.user.Role.MANAGER;
-import static org.springframework.http.HttpMethod.DELETE;
-import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.*;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/alibou/security/token/Token.java
+++ b/src/main/java/com/alibou/security/token/Token.java
@@ -1,42 +1,63 @@
 package com.alibou.security.token;
 
 import com.alibou.security.user.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-@Data
-@Builder
-@NoArgsConstructor
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity
+@Table(name = "token")
 public class Token {
 
   @Id
   @GeneratedValue
-  public Integer id;
+  private Integer id;
 
   @Column(unique = true)
-  public String token;
+  private String tokenCode;
 
   @Enumerated(EnumType.STRING)
-  public TokenType tokenType = TokenType.BEARER;
+  private TokenType tokenType = TokenType.BEARER;
 
-  public boolean revoked;
+  private boolean revoked;
 
-  public boolean expired;
+  private boolean expired;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
+  @ToString.Exclude
   public User user;
+
+  @Override
+  public final boolean equals(Object o) {
+    if (Objects.isNull(o)) {
+      return false;
+    }
+    if (this == o) {
+      return true;
+    }
+    Class<?> oEffectiveClass = o instanceof HibernateProxy hibernateProxy ?
+            hibernateProxy.getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+    Class<?> thisEffectiveClass = this instanceof HibernateProxy hibernateProxy ?
+            hibernateProxy.getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+    if (thisEffectiveClass != oEffectiveClass) {
+      return false;
+    }
+    Token token = (Token) o;
+    return Objects.nonNull(getId()) && Objects.equals(getId(), token.getId());
+  }
+
+  @Override
+  public final int hashCode() {
+    return this instanceof HibernateProxy hibernateProxy ?
+            hibernateProxy.getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+  }
 }

--- a/src/main/java/com/alibou/security/token/TokenRepository.java
+++ b/src/main/java/com/alibou/security/token/TokenRepository.java
@@ -14,5 +14,5 @@ public interface TokenRepository extends JpaRepository<Token, Integer> {
       """)
   List<Token> findAllValidTokenByUser(Integer id);
 
-  Optional<Token> findByToken(String token);
+  Optional<Token> findByTokenCode(String token);
 }

--- a/src/main/java/com/alibou/security/user/Permission.java
+++ b/src/main/java/com/alibou/security/user/Permission.java
@@ -18,5 +18,5 @@ public enum Permission {
     ;
 
     @Getter
-    private final String permission;
+    private final String permissionStr;
 }

--- a/src/main/java/com/alibou/security/user/Role.java
+++ b/src/main/java/com/alibou/security/user/Role.java
@@ -51,7 +51,7 @@ public enum Role {
   public List<SimpleGrantedAuthority> getAuthorities() {
     var authorities = getPermissions()
             .stream()
-            .map(permission -> new SimpleGrantedAuthority(permission.getPermission()))
+            .map(permission -> new SimpleGrantedAuthority(permission.getPermissionStr()))
             .collect(Collectors.toList());
     authorities.add(new SimpleGrantedAuthority("ROLE_" + this.name()));
     return authorities;

--- a/src/main/java/com/alibou/security/user/User.java
+++ b/src/main/java/com/alibou/security/user/User.java
@@ -1,27 +1,22 @@
 package com.alibou.security.user;
 
 import com.alibou.security.token.Token;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.util.Collection;
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-@Data
-@Builder
-@NoArgsConstructor
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "_user")
 public class User implements UserDetails {
@@ -38,7 +33,8 @@ public class User implements UserDetails {
   private Role role;
 
   @OneToMany(mappedBy = "user")
-  private List<Token> tokens;
+  @ToString.Exclude
+  private transient List<Token> tokens;
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -73,5 +69,30 @@ public class User implements UserDetails {
   @Override
   public boolean isEnabled() {
     return true;
+  }
+
+  @Override
+  public final boolean equals(Object o) {
+    if (Objects.isNull(o)) {
+      return false;
+    }
+    if (this == o) {
+      return true;
+    }
+    Class<?> oEffectiveClass = o instanceof HibernateProxy hibernateProxy ?
+            hibernateProxy.getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+    Class<?> thisEffectiveClass = this instanceof HibernateProxy hibernateProxy ?
+            hibernateProxy.getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+    if (thisEffectiveClass != oEffectiveClass) {
+      return false;
+    }
+    User user = (User) o;
+    return Objects.nonNull(getId()) && Objects.equals(getId(), user.getId());
+  }
+
+  @Override
+  public final int hashCode() {
+    return this instanceof HibernateProxy hibernateProxy ?
+            hibernateProxy.getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
   }
 }


### PR DESCRIPTION
This PR intends to refactor key parts of the code to comply with JDK 17+ standards.
Specifically, these are the changes and explanation:

- Usage of a logger `@Sl4j` tool instead of `System` class standard output.
- Rename field `token` from `Token` entity to `tokenCode` and `permission` from `Permission` enum to `permissionStr`. This is to explicitly describe what is the property meaning since they should not have the same name as their class name.
- Replace `== null` and `!= null` with `Objects.isNull` and `Objects.nonNull` to follow functional programming approach.
- Replace `@Data` annotation with `@Getter @Setter @RequiredArgsConstructor @ToString` and explicit `equals hashCode` methods. Using `@Data` for JPA entities is not recommended. It can cause severe performance and memory consumption issues because of lazy load with mapping entities.