### PR TITLE
Upgrade to spring boot 3.1.3 and switch to lambdas for SecurityFilterChain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.1.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.alibou</groupId>

--- a/src/main/java/com/alibou/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/alibou/security/config/SecurityConfiguration.java
@@ -1,15 +1,13 @@
 package com.alibou.security.config;
 
-import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -37,6 +35,8 @@ import static org.springframework.http.HttpMethod.PUT;
 @EnableMethodSecurity
 public class SecurityConfiguration {
 
+  private static final String MANAGEMENT_URL = "/api/v1/management/**";
+
   private final JwtAuthenticationFilter jwtAuthFilter;
   private final AuthenticationProvider authenticationProvider;
   private final LogoutHandler logoutHandler;
@@ -44,54 +44,48 @@ public class SecurityConfiguration {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
-        .csrf()
-        .disable()
-        .authorizeHttpRequests()
-        .requestMatchers(
-                "/api/v1/auth/**",
-                "/v2/api-docs",
-                "/v3/api-docs",
-                "/v3/api-docs/**",
-                "/swagger-resources",
-                "/swagger-resources/**",
-                "/configuration/ui",
-                "/configuration/security",
-                "/swagger-ui/**",
-                "/webjars/**",
-                "/swagger-ui.html"
-        )
-          .permitAll()
+        .csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(a ->
+          a.requestMatchers(
+                  "/api/v1/auth/**",
+                  "/v2/api-docs",
+                  "/v3/api-docs",
+                  "/v3/api-docs/**",
+                  "/swagger-resources",
+                  "/swagger-resources/**",
+                  "/configuration/ui",
+                  "/configuration/security",
+                  "/swagger-ui/**",
+                  "/webjars/**",
+                  "/swagger-ui.html"
+          ).permitAll()
 
 
-        .requestMatchers("/api/v1/management/**").hasAnyRole(ADMIN.name(), MANAGER.name())
+          .requestMatchers(MANAGEMENT_URL).hasAnyRole(ADMIN.name(), MANAGER.name())
 
 
-        .requestMatchers(GET, "/api/v1/management/**").hasAnyAuthority(ADMIN_READ.name(), MANAGER_READ.name())
-        .requestMatchers(POST, "/api/v1/management/**").hasAnyAuthority(ADMIN_CREATE.name(), MANAGER_CREATE.name())
-        .requestMatchers(PUT, "/api/v1/management/**").hasAnyAuthority(ADMIN_UPDATE.name(), MANAGER_UPDATE.name())
-        .requestMatchers(DELETE, "/api/v1/management/**").hasAnyAuthority(ADMIN_DELETE.name(), MANAGER_DELETE.name())
+          .requestMatchers(GET, MANAGEMENT_URL).hasAnyAuthority(ADMIN_READ.name(), MANAGER_READ.name())
+          .requestMatchers(POST, MANAGEMENT_URL).hasAnyAuthority(ADMIN_CREATE.name(), MANAGER_CREATE.name())
+          .requestMatchers(PUT, MANAGEMENT_URL).hasAnyAuthority(ADMIN_UPDATE.name(), MANAGER_UPDATE.name())
+          .requestMatchers(DELETE, MANAGEMENT_URL).hasAnyAuthority(ADMIN_DELETE.name(), MANAGER_DELETE.name())
 
 
-       /* .requestMatchers("/api/v1/admin/**").hasRole(ADMIN.name())
+         /* .requestMatchers("/api/v1/admin/**").hasRole(ADMIN.name())
 
-        .requestMatchers(GET, "/api/v1/admin/**").hasAuthority(ADMIN_READ.name())
-        .requestMatchers(POST, "/api/v1/admin/**").hasAuthority(ADMIN_CREATE.name())
-        .requestMatchers(PUT, "/api/v1/admin/**").hasAuthority(ADMIN_UPDATE.name())
-        .requestMatchers(DELETE, "/api/v1/admin/**").hasAuthority(ADMIN_DELETE.name())*/
+          .requestMatchers(GET, "/api/v1/admin/**").hasAuthority(ADMIN_READ.name())
+          .requestMatchers(POST, "/api/v1/admin/**").hasAuthority(ADMIN_CREATE.name())
+          .requestMatchers(PUT, "/api/v1/admin/**").hasAuthority(ADMIN_UPDATE.name())
+          .requestMatchers(DELETE, "/api/v1/admin/**").hasAuthority(ADMIN_DELETE.name())*/
 
 
-        .anyRequest()
-          .authenticated()
-        .and()
-          .sessionManagement()
-          .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
+          .anyRequest().authenticated())
+        .sessionManagement(s ->
+          s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authenticationProvider(authenticationProvider)
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
-        .logout()
-        .logoutUrl("/api/v1/auth/logout")
-        .addLogoutHandler(logoutHandler)
-        .logoutSuccessHandler((request, response, authentication) -> SecurityContextHolder.clearContext())
+        .logout(l -> l.logoutUrl("/api/v1/auth/logout")
+          .addLogoutHandler(logoutHandler)
+          .logoutSuccessHandler((request, response, authentication) -> SecurityContextHolder.clearContext()))
     ;
 
     return http.build();


### PR DESCRIPTION
Hi there,
I saw the issue #46 this morning and was not fast enough to answer before [ruskyvisky](https://github.com/ruskyvisky) did, but anyway:
Here is a PR for upgrading to spring boot 3.1.3 and I also replaced the method calls on HttpSecurity with lambdas and moved the management URL, which was used in multiple places into a constant.
Please let me know, what you think of this.
Kind regards
the BenchmarkingBuffalo