### PR TITLE
bugfix : prevented creation of duplicate users

### DIFF
--- a/src/main/java/com/alibou/security/auth/AuthenticationService.java
+++ b/src/main/java/com/alibou/security/auth/AuthenticationService.java
@@ -32,14 +32,18 @@ public class AuthenticationService {
   private final AuthenticationManager authenticationManager;
 
   public AuthenticationResponse register(RegisterRequest request) {
-    var user = User.builder()
-        .firstname(request.getFirstname())
-        .lastname(request.getLastname())
-        .email(request.getEmail())
-        .password(passwordEncoder.encode(request.getPassword()))
-        .role(request.getRole())
-        .build();
-    var savedUser = repository.save(user);
+    // Check if the given user exists in database
+    boolean isPresent = repository.findByEmail(request.getEmail()).isPresent();
+    var user = isPresent
+            ? repository.findByEmail(request.getEmail()).get()
+            : User.builder()
+            .firstname(request.getFirstname())
+            .lastname(request.getLastname())
+            .email(request.getEmail())
+            .password(passwordEncoder.encode(request.getPassword()))
+            .role(request.getRole())
+            .build();
+    var savedUser = isPresent ? user : repository.save(user);
     var jwtToken = jwtService.generateToken(user);
     var refreshToken = jwtService.generateRefreshToken(user);
     saveUserToken(savedUser, jwtToken);


### PR DESCRIPTION
Let's say, we'll use the following JSON as a body to the registration POST request : 
```
{
    "firstname": "Hamza",
    "lastname": "Benchrif",
    "email": "hamzaben15@gmail.com",
    "password": "TlkèpI@ka72"
}
```
If you send multiple POST requests with the same JSON body, a user is created each time in the database, thus this leads to duplicate users in the database.

To fix this issue, in AuthenticationService, I added a boolean that checks if the user exists in the database. If it's true just extract the user, otherwise create it & save it to database.