### PR TITLE
Prevent creation of multiple users with the same email

### DIFF
--- a/src/main/java/com/alibou/security/user/User.java
+++ b/src/main/java/com/alibou/security/user/User.java
@@ -1,6 +1,7 @@
 package com.alibou.security.user;
 
 import com.alibou.security.token.Token;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -31,6 +32,7 @@ public class User implements UserDetails {
   private Integer id;
   private String firstname;
   private String lastname;
+  @Column(unique = true)
   private String email;
   private String password;
 


### PR DESCRIPTION
Implemented a unique constraint on the email field within the User entity to prevent the registration of multiple users with the same email. This is essential as the authentication process relies on the findByEmail method, which must only find one user per email, ensuring integrity in authentication.