### PR TITLE
fix: logical expression in TokenRepository

### DIFF
--- a/src/main/java/com/alibou/security/token/TokenRepository.java
+++ b/src/main/java/com/alibou/security/token/TokenRepository.java
@@ -10,7 +10,7 @@ public interface TokenRepository extends JpaRepository<Token, Integer> {
   @Query(value = """
       select t from Token t inner join User u\s
       on t.user.id = u.id\s
-      where u.id = :id and (t.expired = false or t.revoked = false)\s
+      where u.id = :id and (t.expired = false and t.revoked = false)\s
       """)
   List<Token> findAllValidTokenByUser(Integer id);
 


### PR DESCRIPTION
Changed `or` to `and` in the JPQL query for `findAllValidTokenByUser(Integer id)`,  so that only one of `expired` or `revoked` being set to `true` is sufficient to invalidate the token.