### PR TITLE
fixed issue of duplicate user creation and 403 authorization error

### DIFF
--- a/src/main/java/com/alibou/security/auth/AuthenticationService.java
+++ b/src/main/java/com/alibou/security/auth/AuthenticationService.java
@@ -39,10 +39,17 @@ public class AuthenticationService {
         .password(passwordEncoder.encode(request.getPassword()))
         .role(request.getRole())
         .build();
-    var savedUser = repository.save(user);
+
+    if(!repository.existsCurrentAccountByEmail(request.getEmail()))
+    {
+        var savedUser = repository.save(user);
+        var jwtToken = jwtService.generateToken(user);
+        saveUserToken(savedUser, jwtToken);
+    }
+  
     var jwtToken = jwtService.generateToken(user);
     var refreshToken = jwtService.generateRefreshToken(user);
-    saveUserToken(savedUser, jwtToken);
+    
     return AuthenticationResponse.builder()
         .accessToken(jwtToken)
             .refreshToken(refreshToken)

--- a/src/main/java/com/alibou/security/user/UserRepository.java
+++ b/src/main/java/com/alibou/security/user/UserRepository.java
@@ -7,4 +7,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
   Optional<User> findByEmail(String email);
 
+  boolean existsCurrentAccountByEmail(String email);
+
 }


### PR DESCRIPTION
duplicate users are getting created even if the user exists in db.
This fix will check if the data already exists by using emailId as unique Identifier and add if it doesn't exists.
